### PR TITLE
tmuxステータスバーのカレントウィンドウインジケーターを変更

### DIFF
--- a/configs/tmux/.config/tmux/tmux.conf
+++ b/configs/tmux/.config/tmux/tmux.conf
@@ -61,7 +61,7 @@ set -g status-right ' #H | %Y/%m/%d(%a) %H:%M:%S '
 set -g status-right-length 80
 set -g window-status-separator ''
 set -g window-status-format ' #I:#W '
-set -g window-status-current-format ' [ #I:#W ] '
+set -g window-status-current-format " #[fg=green,bold]*#[default]#I:#W "
 
 # message
 set -g message-style fg="$TMUX_COLOR_WHITE",bg="$TMUX_COLOR_ACCENT"


### PR DESCRIPTION
`[ 1.vim ] 2.zsh`
↓
`*1.vim 2.zsh`